### PR TITLE
Added configuration option to listen to all addresses or localhost (::1) only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ Version.cpp
 CMakeCache.txt
 CMakeFiles/*
 cmake_install.cmake
-
+.idea/

--- a/Logger/LoggerServer.h
+++ b/Logger/LoggerServer.h
@@ -74,7 +74,7 @@ namespace Logger
 
 		private:
 			inline LoggerServer()
-			:	Network::TcpServer(defaultLoggerPort, "Logger"),
+			:	Network::TcpServer("::1", defaultLoggerPort, "Logger"),
 			 	run(true),
 			 	fileLoggerStarted(false),
 			 	consoleLoggerStarted(false)

--- a/Logger/LoggerServer.h
+++ b/Logger/LoggerServer.h
@@ -74,7 +74,7 @@ namespace Logger
 
 		private:
 			inline LoggerServer()
-			:	Network::TcpServer("::1", defaultLoggerPort, "Logger"),
+			:	Network::TcpServer("any", defaultLoggerPort, "Logger"),
 			 	run(true),
 			 	fileLoggerStarted(false),
 			 	consoleLoggerStarted(false)

--- a/Manager.cpp
+++ b/Manager.cpp
@@ -88,7 +88,7 @@ Manager::Manager(Config& config)
 	selectRouteApproach = static_cast<DataModel::SelectRouteApproach>(Utils::Utils::StringToInteger(storage->GetSetting("SelectRouteApproach")));
 	nrOfTracksToReserve = static_cast<DataModel::Loco::NrOfTracksToReserve>(Utils::Utils::StringToInteger(storage->GetSetting("NrOfTracksToReserve"), 2));
 
-	controls[ControlIdWebserver] = new WebServer::WebServer(*this, config.getValue("listen_address", "::"), config.getValue("webserverport", 8082));
+	controls[ControlIdWebserver] = new WebServer::WebServer(*this, config.getValue("webserveraddress", "any"), config.getValue("webserverport", 8082));
 
 	storage->AllHardwareParams(hardwareParams);
 	for (auto& hardwareParam : hardwareParams)

--- a/Manager.cpp
+++ b/Manager.cpp
@@ -88,7 +88,7 @@ Manager::Manager(Config& config)
 	selectRouteApproach = static_cast<DataModel::SelectRouteApproach>(Utils::Utils::StringToInteger(storage->GetSetting("SelectRouteApproach")));
 	nrOfTracksToReserve = static_cast<DataModel::Loco::NrOfTracksToReserve>(Utils::Utils::StringToInteger(storage->GetSetting("NrOfTracksToReserve"), 2));
 
-	controls[ControlIdWebserver] = new WebServer::WebServer(*this, config.getValue("webserverport", 8082));
+	controls[ControlIdWebserver] = new WebServer::WebServer(*this, config.getValue("listen_address", "::"), config.getValue("webserverport", 8082));
 
 	storage->AllHardwareParams(hardwareParams);
 	for (auto& hardwareParam : hardwareParams)

--- a/Network/TcpServer.cpp
+++ b/Network/TcpServer.cpp
@@ -33,7 +33,7 @@ along with RailControl; see the file LICENCE. If not see
 
 namespace Network
 {
-	TcpServer::TcpServer(const unsigned short port, const std::string& threadName)
+	TcpServer::TcpServer(const std::string& address, const unsigned short port, const std::string& threadName)
 	:	run(false),
 	 	error(""),
 	 	threadName(threadName)
@@ -41,7 +41,12 @@ namespace Network
 		struct sockaddr_in6 serverAddr6;
 		memset(reinterpret_cast<char*>(&serverAddr6), 0, sizeof(serverAddr6));
 		serverAddr6.sin6_family = AF_INET6;
-		serverAddr6.sin6_addr = in6addr_any;
+
+		if(address == "::1") {
+            serverAddr6.sin6_addr = IN6ADDR_LOOPBACK_INIT;
+        } else {
+            serverAddr6.sin6_addr = in6addr_any;
+		}
 		serverAddr6.sin6_port = htons(port);
 		SocketCreateBindListen(serverAddr6.sin6_family, reinterpret_cast<struct sockaddr*>(&serverAddr6));
 

--- a/Network/TcpServer.cpp
+++ b/Network/TcpServer.cpp
@@ -42,7 +42,7 @@ namespace Network
 		memset(reinterpret_cast<char*>(&serverAddr6), 0, sizeof(serverAddr6));
 		serverAddr6.sin6_family = AF_INET6;
 
-		if(address == "::1") {
+		if(address == "localhost") {
             serverAddr6.sin6_addr = IN6ADDR_LOOPBACK_INIT;
         } else {
             serverAddr6.sin6_addr = in6addr_any;

--- a/Network/TcpServer.h
+++ b/Network/TcpServer.h
@@ -38,7 +38,7 @@ namespace Network
 			TcpServer& operator=(const TcpServer&) = delete;
 
 		protected:
-			TcpServer(const unsigned short port, const std::string& threadName);
+			TcpServer(const std::string& address, const unsigned short port, const std::string& threadName);
 			virtual ~TcpServer();
 			void TerminateTcpServer();
 

--- a/WebServer/WebServer.cpp
+++ b/WebServer/WebServer.cpp
@@ -54,9 +54,9 @@ namespace WebServer
 	const std::string WebServer::UpdateStatus = "data: status=";
 	const std::string WebServer::Webserver = "Webserver";
 
-	WebServer::WebServer(Manager& manager, const std::string& listen_address, const unsigned short port)
+	WebServer::WebServer(Manager& manager, const std::string& webserveraddress, const unsigned short port)
 	:	ControlInterface(ControlTypeWebserver),
-		Network::TcpServer(listen_address, port, "WebServer"),
+		Network::TcpServer(webserveraddress, port, "WebServer"),
 		logger(Logger::Logger::GetLogger("WebServer")),
 		run(false),
 		lastClientID(0),
@@ -69,7 +69,7 @@ namespace WebServer
 			updates[updateID] = GetStatus(Languages::TextRailControlStarted);
 		}
 		run = true;
-		LogBrowserInfo(listen_address, port);
+		LogBrowserInfo(webserveraddress, port);
 	}
 
 	WebServer::~WebServer()
@@ -102,66 +102,58 @@ namespace WebServer
 		logger->Info(Languages::TextWebServerStopped);
 	}
 
-	void WebServer::LogBrowserInfo(const std::string& listen_address, const unsigned short port)
+	void WebServer::LogBrowserInfo(const std::string& webserveraddress, const unsigned short port)
 	{
-        static const string Http("\n   http://");
-        static const string Port(to_string(port));
+		static const string Http("\n   http://");
+		static const string Port(to_string(port));
 
-        if(listen_address != "::1") {
+		string localhostInfo(Http);
+		localhostInfo += "localhost:" + Port + "/";
+		string ipv4Info;
+		string ipv6Info;
 
-            string localhostInfo(Http);
-            localhostInfo += "localhost:" + Port + "/";
-            string ipv4Info;
-            string ipv6Info;
+		struct ifaddrs* ifAddrStruct = nullptr;
+		struct ifaddrs* ifa = nullptr;
+		getifaddrs(&ifAddrStruct);
 
-            struct ifaddrs* ifAddrStruct = nullptr;
-            struct ifaddrs* ifa = nullptr;
-            getifaddrs(&ifAddrStruct);
+		if(webserveraddress != "localhost") {
 
-            for (ifa = ifAddrStruct; ifa != nullptr; ifa = ifa->ifa_next)
-            {
-                if (!ifa->ifa_addr)
-                {
-                    continue;
-                }
-                if (ifa->ifa_addr->sa_family == AF_INET)
-                { // check it is IP4
-                    // is a valid IP4 Address
-                    void* tmpAddrPtr = &((struct sockaddr_in*) ifa->ifa_addr)->sin_addr;
-                    char addressBuffer[INET_ADDRSTRLEN];
-                    inet_ntop(AF_INET, tmpAddrPtr, addressBuffer, INET_ADDRSTRLEN);
-                    string address(addressBuffer);
-                    if (address.compare("0.0.0.0") == 0)
-                    {
-                        continue;
-                    }
-                    if (address.substr(0, 8).compare("169.254.") == 0)
-                    {
-                        continue;
-                    }
-                    ipv4Info += Http + addressBuffer + ":" + Port + "/";
-                }
-                else if (ifa->ifa_addr->sa_family == AF_INET6)
-                { // check it is IP6
-                    // is a valid IP6 Address
-                    void* tmpAddrPtr = &((struct sockaddr_in6*) ifa->ifa_addr)->sin6_addr;
-                    char addressBuffer[INET6_ADDRSTRLEN];
-                    inet_ntop(AF_INET6, tmpAddrPtr, addressBuffer, INET6_ADDRSTRLEN);
-                    ipv4Info += Http + "[" + addressBuffer + "]:" + Port + "/";
-                }
-            }
-            if (ifAddrStruct != NULL)
-            {
-                freeifaddrs(ifAddrStruct);
-            }
+			for (ifa = ifAddrStruct; ifa != nullptr; ifa = ifa->ifa_next) {
+				if (!ifa->ifa_addr) {
+					continue;
+				}
+				if (ifa->ifa_addr->sa_family == AF_INET) { // check it is IP4
+					// is a valid IP4 Address
+					void *tmpAddrPtr = &((struct sockaddr_in *) ifa->ifa_addr)->sin_addr;
+					char addressBuffer[INET_ADDRSTRLEN];
+					inet_ntop(AF_INET, tmpAddrPtr, addressBuffer, INET_ADDRSTRLEN);
+					string address(addressBuffer);
+					if (address.compare("0.0.0.0") == 0) {
+						continue;
+					}
+					if (address.substr(0, 8).compare("169.254.") == 0) {
+						continue;
+					}
+					ipv4Info += Http + addressBuffer + ":" + Port + "/";
+				}
+				if (ifa->ifa_addr->sa_family == AF_INET6) { // check it is IP6
+					// is a valid IP6 Address
+					void *tmpAddrPtr = &((struct sockaddr_in6 *) ifa->ifa_addr)->sin6_addr;
+					char addressBuffer[INET6_ADDRSTRLEN];
+					inet_ntop(AF_INET6, tmpAddrPtr, addressBuffer, INET6_ADDRSTRLEN);
+					ipv4Info += Http + "[" + addressBuffer + "]:" + Port + "/";
+				}
+			}
 
-            logger->Info(Languages::TextBrowserInfo, localhostInfo, ipv4Info, ipv6Info);
-
-        } else {
-            string localhostInfo(Http);
-            localhostInfo += "[::1]:" + Port + "/";
-            logger->Info(Languages::TextBrowserInfo, localhostInfo, "", "");
 		}
+
+		if (ifAddrStruct != NULL)
+		{
+			freeifaddrs(ifAddrStruct);
+		}
+
+		logger->Info(Languages::TextBrowserInfo, localhostInfo, ipv4Info, ipv6Info);
+
 	}
 
 	void WebServer::Work(Network::TcpConnection* connection)

--- a/WebServer/WebServer.h
+++ b/WebServer/WebServer.h
@@ -42,7 +42,7 @@ namespace WebServer
 			WebServer(const WebServer&) = delete;
 			WebServer& operator=(const WebServer&) = delete;
 
-			WebServer(Manager& manager, const std::string& listen_address, const unsigned short port);
+			WebServer(Manager& manager, const std::string& webserveraddress, const unsigned short port);
 			~WebServer();
 
 			void Work(Network::TcpConnection* connection) override;
@@ -111,7 +111,7 @@ namespace WebServer
 
 			void TrackBaseState(std::string& command, const DataModel::TrackBase* track);
 
-			void LogBrowserInfo(const std::string& listen_address, const unsigned short port);
+			void LogBrowserInfo(const std::string& webserveraddress, const unsigned short port);
 
 			Logger::Logger* logger;
 			volatile bool run;

--- a/WebServer/WebServer.h
+++ b/WebServer/WebServer.h
@@ -42,7 +42,7 @@ namespace WebServer
 			WebServer(const WebServer&) = delete;
 			WebServer& operator=(const WebServer&) = delete;
 
-			WebServer(Manager& manager, const unsigned short port);
+			WebServer(Manager& manager, const std::string& listen_address, const unsigned short port);
 			~WebServer();
 
 			void Work(Network::TcpConnection* connection) override;
@@ -111,7 +111,7 @@ namespace WebServer
 
 			void TrackBaseState(std::string& command, const DataModel::TrackBase* track);
 
-			void LogBrowserInfo(const unsigned short port);
+			void LogBrowserInfo(const std::string& listen_address, const unsigned short port);
 
 			Logger::Logger* logger;
 			volatile bool run;

--- a/railcontrol.conf.dist
+++ b/railcontrol.conf.dist
@@ -8,9 +8,9 @@ dbfilename = railcontrol.sqlite
 # Default dbkeepbackups is 10
 dbkeepbackups = 10
 
-# If this is set to :: the webserver will listen to all addresses
-# If this is set to ::1 the webserver will listen to the IPv6 localhost address only
-listen_address = ::
+# If this is set to any the webserver will listen to all addresses
+# If this is set to localhost the webserver will listen to the IPv6 localhost address only
+webserveraddress = any
 
 # Default webserver port is 80, but
 # RailControl should not be started as root.

--- a/railcontrol.conf.dist
+++ b/railcontrol.conf.dist
@@ -8,6 +8,10 @@ dbfilename = railcontrol.sqlite
 # Default dbkeepbackups is 10
 dbkeepbackups = 10
 
+# If this is set to :: the webserver will listen to all addresses
+# If this is set to ::1 the webserver will listen to the IPv6 localhost address only
+listen_address = ::
+
 # Default webserver port is 80, but
 # RailControl should not be started as root.
 # Therefore we use alternate port 8082


### PR DESCRIPTION
Hey Teddy,

in this branch I implemented a quick solution to make the Webserver listen to `::1` only. What is the `LoggingServer` used for? This branch restricts it to `::1` in general. Maybe we need a solution for this, too? But it's a problem, because the Logging Server is initialized and used before the configuration has been read? :thinking: 

Thanks

Mebus
