### PR TITLE
Fix compile error due to -Werror=stringop-overread

### DIFF
--- a/Hardware/Hsi88.cpp
+++ b/Hardware/Hsi88.cpp
@@ -88,7 +88,7 @@ namespace Hardware
 	std::string Hsi88::ReadUntilCR()
 	{
 		std::string data;
-		unsigned char input = 0;
+		unsigned char input;
 		while (true)
 		{
 			int ret = serialLine.Receive(&input, sizeof(input), 1, 0);
@@ -97,7 +97,7 @@ namespace Hardware
 				logger->HexIn(data);
 				return data;
 			}
-			data.append(reinterpret_cast<char*>(&input), ret);
+			data.append(reinterpret_cast<char*>(&input));
 		}
 	}
 


### PR DESCRIPTION
While trying to compile on Fedora rawhide with some patches attached to have stricter security checks the follow error appears.

```
In function ‘copy’,
    inlined from ‘_S_copy’ at /usr/include/c++/15/bits/basic_string.h:453:21,
    inlined from ‘_S_copy’ at /usr/include/c++/15/bits/basic_string.h:448:7,
    inlined from ‘_M_append’ at /usr/include/c++/15/bits/basic_string.tcc:452:19,
    inlined from ‘append’ at /usr/include/c++/15/bits/basic_string.h:1570:18,
    inlined from ‘ReadUntilCR’ at /builddir/build/BUILD/railcontrol-24-build/railcontrol-24/Hardware/Hsi88.cpp:100:15,
    inlined from ‘GetVersion’ at /builddir/build/BUILD/railcontrol-24-build/railcontrol-24/Hardware/Hsi88.cpp:108:22,
    inlined from ‘__ct_base ’ at /builddir/build/BUILD/railcontrol-24-build/railcontrol-24/Hardware/Hsi88.cpp:63:36:
/usr/include/c++/15/bits/char_traits.h:429:56: error: ‘__builtin_memcpy’ reading between 2 and 2147483647 bytes from a region of size 1 [-Werror=stringop-overread]
  429 |         return static_cast<char_type*>(__builtin_memcpy(__s1, __s2, __n));
      |                                                        ^
/builddir/build/BUILD/railcontrol-24-build/railcontrol-24/Hardware/Hsi88.cpp: In member function ‘__ct_base ’:
/builddir/build/BUILD/railcontrol-24-build/railcontrol-24/Hardware/Hsi88.cpp:91:31: note: source object ‘input’ of size 1
   91 |                 unsigned char input;
      |                               ^
lto1: all warnings being treated as errors
```

My reading of the original implementation is it uses the return code ret as a length of how much data to copy. This can be larger than the size of input, which is why the check fails.

Fixes #13