### PR TITLE
Allow building with sqlite3 and zlib as system libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,9 +50,6 @@ project(railcontrol VERSION ${RAILCONTROL_VERSION})
 STRING(TIMESTAMP COMPILE_TIMESTAMP "%s" UTC)
 
 add_executable(${PROJECT_NAME}
-Storage/sqlite/sqlite3.c
-Storage/sqlite/sqlite3.h
-Storage/sqlite/sqlite3ext.h
 Manager.cpp
 Manager.h
 Server/Web/WebClient.cpp
@@ -317,33 +314,56 @@ Utils/Utils.cpp
 Utils/Utils.h
 ${CMAKE_CURRENT_BINARY_DIR}/Version.cpp
 Version.h
-Hardware/zlib/adler32.c
-Hardware/zlib/compress.c
-Hardware/zlib/crc32.c
-Hardware/zlib/crc32.h
-Hardware/zlib/deflate.c
-Hardware/zlib/deflate.h
-Hardware/zlib/gzclose.c
-Hardware/zlib/gzguts.h
-Hardware/zlib/gzlib.c
-Hardware/zlib/gzread.c
-Hardware/zlib/gzwrite.c
-Hardware/zlib/infback.c
-Hardware/zlib/inffast.c
-Hardware/zlib/inffast.h
-Hardware/zlib/inffixed.h
-Hardware/zlib/inflate.c
-Hardware/zlib/inflate.h
-Hardware/zlib/inftrees.c
-Hardware/zlib/inftrees.h
-Hardware/zlib/trees.c
-Hardware/zlib/trees.h
-Hardware/zlib/uncompr.c
-Hardware/zlib/zconf.h
-Hardware/zlib/zlib.h
-Hardware/zlib/zutil.c
-Hardware/zlib/zutil.h
 )
+
+option(USE_SYSTEM_LIBRARIES "Build with system libraries" OFF)
+
+if (USE_SYSTEM_LIBRARIES)
+	find_package(SQLite3)
+	target_link_libraries(${PROJECT_NAME} PRIVATE SQLite::SQLite3)
+
+	find_package(ZLIB)
+	target_link_libraries(${PROJECT_NAME} PRIVATE ZLIB::ZLIB)
+else()
+	target_include_directories(${PROJECT_NAME} PRIVATE Storage/sqlite)
+	add_library(sqlite3 STATIC
+		Storage/sqlite/sqlite3.c
+		Storage/sqlite/sqlite3.h
+		Storage/sqlite/sqlite3ext.h
+	)
+	target_link_libraries(${PROJECT_NAME} PRIVATE sqlite3)
+
+	target_include_directories(${PROJECT_NAME} PRIVATE Hardware/zlib)
+	add_library(zlib STATIC
+		Hardware/zlib/adler32.c
+		Hardware/zlib/compress.c
+		Hardware/zlib/crc32.c
+		Hardware/zlib/crc32.h
+		Hardware/zlib/deflate.c
+		Hardware/zlib/deflate.h
+		Hardware/zlib/gzclose.c
+		Hardware/zlib/gzguts.h
+		Hardware/zlib/gzlib.c
+		Hardware/zlib/gzread.c
+		Hardware/zlib/gzwrite.c
+		Hardware/zlib/infback.c
+		Hardware/zlib/inffast.c
+		Hardware/zlib/inffast.h
+		Hardware/zlib/inffixed.h
+		Hardware/zlib/inflate.c
+		Hardware/zlib/inflate.h
+		Hardware/zlib/inftrees.c
+		Hardware/zlib/inftrees.h
+		Hardware/zlib/trees.c
+		Hardware/zlib/trees.h
+		Hardware/zlib/uncompr.c
+		Hardware/zlib/zconf.h
+		Hardware/zlib/zlib.h
+		Hardware/zlib/zutil.c
+		Hardware/zlib/zutil.h
+	)
+	target_link_libraries(${PROJECT_NAME} PRIVATE zlib)
+endif()
 
 set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 set(CMAKE_CXX_STANDARD 11)

--- a/Hardware/ZLib.cpp
+++ b/Hardware/ZLib.cpp
@@ -19,8 +19,8 @@ along with RailControl; see the file LICENCE. If not see
 */
 
 #include <string>
+#include <zlib.h>
 
-#include "Hardware/zlib/zlib.h"
 #include "Hardware/ZLib.h"
 #include "Utils/Utils.h"
 

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,15 @@ TMPDIR=/tmp/RailControl
 TMPDIRCYGWIN=/RailControl
 
 CXXOBJ= $(patsubst %.cpp,%.o,$(sort Version.cpp $(wildcard *.cpp)) $(wildcard Server/Web/*.cpp Server/CS2/*.cpp Server/Z21/*.cpp DataModel/*.cpp Hardware/*.cpp Hardware/Protocols/*.cpp Logger/*.cpp Network/*.cpp Storage/*.cpp Utils/*.cpp))
+
+ifdef USE_SYSTEM_LIBRARIES
+LIBS+= -lsqlite3 -lz
+OBJ=$(CXXOBJ)
+else
+CXXFLAGS+= -IStorage/sqlite -IHardware/zlib
 COBJ= $(patsubst %.c,%.o,$(wildcard Hardware/zlib/*.c))
 OBJ=Storage/sqlite/sqlite3.o $(CXXOBJ) $(COBJ)
+endif
 
 SOURCE_DATE_EPOCH?=$(shell date +%s)
 

--- a/Storage/Sqlite.h
+++ b/Storage/Sqlite.h
@@ -21,10 +21,10 @@ along with RailControl; see the file LICENCE. If not see
 #pragma once
 
 #include <map>
+#include <sqlite3.h>
 
 #include "DataModel/DataModel.h"
 #include "Logger/Logger.h"
-#include "Storage/sqlite/sqlite3.h"
 #include "Storage/StorageInterface.h"
 #include "Storage/StorageParams.h"
 


### PR DESCRIPTION
These are technically standalone projects and should be treated as such. It is now possible to build and link against the system libraries.

Using CMake:

```sh
cmake -B build -D USE_SYSTEM_LIBRARIES=ON
cmake --build build
```

Using make:

```sh
export USE_SYSTEM_LIBRARIES=1
make
```