### PR TITLE
Support basic packaging using CPack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,3 +360,12 @@ target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads dl)
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_SOURCE_DIR})
 
 configure_file(Version.cpp.in Version.cpp @ONLY)
+
+set(CMAKE_INSTALL_BINDIR ".")
+set(DATADIR ".")
+
+install(TARGETS ${PROJECT_NAME})
+install(FILES railcontrol.conf.dist DESTINATION ${DATADIR})
+install(DIRECTORY html DESTINATION ${DATADIR})
+
+include(CPack)


### PR DESCRIPTION
This allows creating release artifacts:

```
cmake -B build
cd build
cpack
```

This will create the right generators based on the platform it runs on. It's also possible to explicitly select the generator:

```
cpack -G TXZ
```

This currently works for Linux builds to create a cmake equivalent of `make dist`, though I have not verified if it stips the binaries.

What does not work yet is the cygwin binary build. Reading https://cmake.org/cmake/help/book/mastering-cmake/chapter/Packaging%20With%20CPack.html#cpack-for-cygwin-setup that is specifically for creating a cygwin package, not a vendored package. I have started to look into [CMake BundleUtilies](https://cmake.org/cmake/help/latest/module/BundleUtilities.html) to vendor in the cygwin files but have not found a good way. I'm starting to wonder if it's easier to port it to properly support Windows socket APIs instead.

In the short term I think it's still good to merge this as a base because I want to build on it later.

Link: https://cmake.org/cmake/help/book/mastering-cmake/chapter/Packaging%20With%20CPack.html