### PR TITLE
Check if stdin is a tty

### DIFF
--- a/RailControl.cpp
+++ b/RailControl.cpp
@@ -24,7 +24,7 @@ along with RailControl; see the file LICENCE. If not see
 #include <iostream>
 #include <signal.h>
 #include <sstream>
-#include <unistd.h>		//close;
+#include <unistd.h>		//close; isatty
 #include <vector>
 
 #include "ArgumentHandler.h"
@@ -183,7 +183,7 @@ int main (int argc, char* argv[])
 		// wait for q or r followed by \n or SIGINT or SIGTERM
 		do
 		{
-			if (silent)
+			if (!isatty(STDIN_FILENO) || silent)
 			{
 				Utils::Utils::SleepForSeconds(1);
 			}


### PR DESCRIPTION
When stdin links to /dev/null, which is the case for systemd service units, select() returns immediately. That causes the loop to endlessly read() 0 bytes and eats up 100% of a processor core.

isatty() checks if railcontrol has a "real" stdin available. If that is not the case, do not select() and read() stdin but use the 1s delay as for silent mode and avoid spinning at 100%.