### PR TITLE
Require CMake 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
 	find_package(Git QUIET)


### PR DESCRIPTION
CMake 3.31 have deprecated anything older than 3.10 and this silences the deprecation warning.

Link: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html